### PR TITLE
Phase2

### DIFF
--- a/pxe_manager/pxemanager.py
+++ b/pxe_manager/pxemanager.py
@@ -158,6 +158,14 @@ class PxeManager(object):
         return
 
     def put_file_on_target(self, ip, file_name):
+        """
+        SSH to a host and touch a file there. We can later check for this files existence to determine whether a
+        kickstart completed successfully.
+
+        :param ip: (string) IP address of host
+        :param file_name: name of file to create
+        :return:
+        """
         ssh = SSHClient()
         ssh.set_missing_host_key_policy(AutoAddPolicy())  # wont require saying 'yes' to new fingerprint
         ssh.connect(ip, username=self.ssh_user, password=self.ssh_password)
@@ -166,6 +174,13 @@ class PxeManager(object):
         return
 
     def check_for_file_on_target(self, ip, file_name):
+        """
+        SSH to a host and check for the presence of a file.
+
+        :param ip: (string) IP of a host
+        :param file_name: Name of file to check if it exists
+        :return: True if the file was found
+        """
         ssh = SSHClient()
         ssh.set_missing_host_key_policy(AutoAddPolicy())  # wont require saying 'yes' to new fingerprint
         ssh.connect(ip, username=self.ssh_user, password=self.ssh_password)


### PR DESCRIPTION
Most of this has been in alpha use over the weekend. New additions _not_ in alpha production include:
1. Documentation
2. PxeManager **init** has 2 more parameters that allow for specifying the username/password to use for ssh connection

The initial ssh stuff is serial. I don't think this is critical right now to move this to threads. What happens is the ssh connection tries and tries until it succeeds. then move to the next. After the first, the other hosts _should_ be up and each will have successful ssh connection in 1 possibly 2 attempts. So the time will not greatly increase with a threaded model. However, IMHO, it is the right thing to do later.
