### PR TITLE
report correct hostname when removing resource from reservation

### DIFF
--- a/pxe_manager/pxemanager.py
+++ b/pxe_manager/pxemanager.py
@@ -118,7 +118,7 @@ class PxeManager(object):
         for resource in self.host_reservation:
             print "Checking status of " + resource
             if not self.is_system_ready(system_name=resource):
-                print "INFO:", hostname, "was not ready within allotted time. Removing host from reservation."
+                print "INFO:", resource, "was not ready within allotted time. Removing host from reservation."
                 self.host_reservation.remove(resource)
                 print "INFO: attempting to allocate another machine."
                 self.make_host_reservation(owner=owner, count=1, job_id=job_id, distro=distro)


### PR DESCRIPTION
This was seen today where it reported a host was being removed from the reservation but it went on to check the status of that host, example:
```
File that was created on d-11.qa1.eucalyptus-systems.com before kickstart was not detected.
KICKSTART SUCCEEDED!
INFO: updating d-11.qa1.eucalyptus-systems.com status to in_use
Checking status of d-41.qa1.eucalyptus-systems.com
Attempting ssh to 10.111.5.103.....1/45
[Errno None] Unable to connect to port 22 on  or 10.111.5.103
...
Attempting ssh to 10.111.5.103.....45/45
[Errno None] Unable to connect to port 22 on  or 10.111.5.103
INFO: updating d-41.qa1.eucalyptus-systems.com status to pxe_failed
INFO: g-15-02.qa1.eucalyptus-systems.com was not ready within allotted time. Removing host from reservation.
INFO: attempting to allocate another machine.
```