### PR TITLE
Add rhel/centos 6.7 distros for faststart/maint4.x jobs to use

### DIFF
--- a/pxe_manager/pxemanager.py
+++ b/pxe_manager/pxemanager.py
@@ -64,7 +64,9 @@ class PxeManager(object):
         self.ssh_user = ssh_user
         self.ssh_password = ssh_password
         self.distro = {'centos': 'centos6-x86_64-raid0',
-                       'rhel': 'rhel6u6-x86_64-raid0',
+                       'rhel': 'rhel6-x86_64-raid0',
+                       'centos6u7': 'centos6u7-x86_64-raid0',
+                       'rhel6u7': 'rhel6u7-x86_64-raid0',
                        'centos7': 'centos7-x86_64-raid0',
                        'centos70': 'centos7u0-x86_64-raid0',
                        'rhel7': 'rhel7-x86_64-raid0'}

--- a/pxe_manager/tests/test_pxemanager.py
+++ b/pxe_manager/tests/test_pxemanager.py
@@ -21,7 +21,9 @@ def test_defaults():
                         </methodResponse>
     '''
     distro_map = {'centos': 'centos6-x86_64-raid0',
-                  'rhel': 'rhel6u6-x86_64-raid0',
+                  'rhel': 'rhel6-x86_64-raid0',
+                  'centos6u7': 'centos6u7-x86_64-raid0',
+                  'rhel6u7': 'rhel6u7-x86_64-raid0',
                   'centos7': 'centos7-x86_64-raid0',
                   'centos70': 'centos7u0-x86_64-raid0',
                   'rhel7': 'rhel7-x86_64-raid0'}


### PR DESCRIPTION
CI and Quick Launch Master will use the latest